### PR TITLE
Allow to pass variables with body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@andvea/shopify-graphql-client",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@andvea/shopify-graphql-client",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "dotenv": "^16.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andvea/shopify-graphql-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "ShopifyGraphQL.js",
   "files": [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,7 @@ dotenv.config({
 var shopifyGraphQL =
   new ShopifyGraphQL({
     timeout: 2,
-    apiEndpoint: 'https://'+process.env.SHOP_MYSHOPIFY_DOMAIN+'/admin/api/2023-04/graphql.json',
+    apiEndpoint: 'https://'+process.env.SHOP_MYSHOPIFY_DOMAIN+'/admin/api/2024-07/graphql.json',
     apiKey: process.env.SHOP_API_KEY,
     retryThrottles: false,
     maxConcurrentRequests: 50
@@ -37,6 +37,48 @@ describe('GraphQL Errors', function() {
         id 
       } 
     }`).then((v) => {
+      done();
+    }).catch((reqErr) => {
+      done(new Error(reqErr));
+    });
+  });
+
+  it('Succesfull request with variables', (done) => {
+    let QUERY = `mutation productVariantsBulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+      productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+        productVariants {
+          id
+          media(first: 10) {
+            nodes {
+              id
+            }
+          }
+        }
+        userErrors {
+          field
+          message
+        }
+      }
+    }`;
+
+    let VARIABLES = {
+      productId: "gid://shopify/Product/6658141683841",
+      variants: [
+        {
+          id: "gid://shopify/ProductVariant/39674648395905",
+          price: "21.00"
+        },
+        {
+          id: "gid://shopify/ProductVariant/39674648494209",
+          price: "22.00"
+        }
+      ]
+    };
+
+    shopifyGraphQL.request(JSON.stringify({
+        query: QUERY,
+        variables: VARIABLES
+      }), 'application/json').then((v) => {
       done();
     }).catch((reqErr) => {
       done(new Error(reqErr));


### PR DESCRIPTION
Variables should be passed as outlined in the official [GraphQL documentation](https://graphql.org/graphql-js/passing-arguments/), rather than being hardcoded into the query body. The only required edit to allow this is to accept the `content-type` header of the request as argument (which should be `application/json` when passing variables, otherwise `application/graphql`)